### PR TITLE
Using default MainActivity intent

### DIFF
--- a/app/src/main/java/com/jzallas/backdrop/MainActivity.kt
+++ b/app/src/main/java/com/jzallas/backdrop/MainActivity.kt
@@ -2,6 +2,7 @@ package com.jzallas.backdrop
 
 import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
 import android.content.ServiceConnection
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
@@ -16,6 +17,10 @@ import com.jzallas.backdrop.service.MediaService
 import kotlinx.android.synthetic.main.main_activity.*
 
 class MainActivity : AppCompatActivity(), ServiceConnection {
+
+  companion object {
+    fun createIntent(context: Context) = Intent(context, MainActivity::class.java)
+  }
 
   private lateinit var viewModel: MainViewModel
 
@@ -32,6 +37,9 @@ class MainActivity : AppCompatActivity(), ServiceConnection {
     viewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
 
     ActivityCompat.startForegroundService(this, mediaServiceIntent)
+
+    // switch to default intent so we don't replay a share intent
+    intent = createIntent(this)
   }
 
   override fun onStart() {

--- a/app/src/main/java/com/jzallas/backdrop/service/MediaService.kt
+++ b/app/src/main/java/com/jzallas/backdrop/service/MediaService.kt
@@ -160,9 +160,13 @@ class MediaService : LifecycleService(), MediaDescriptionAdapter, NotificationLi
     super.onDestroy()
   }
 
-  override fun createCurrentContentIntent(player: Player): PendingIntent =
-    Intent(this, MainActivity::class.java)
-      .let { PendingIntent.getActivity(this, 0, it, PendingIntent.FLAG_UPDATE_CURRENT) }
+  override fun createCurrentContentIntent(player: Player) =
+    PendingIntent.getActivity(
+      this,
+      0,
+      MainActivity.createIntent(this),
+      PendingIntent.FLAG_UPDATE_CURRENT
+    )
 
   override fun getCurrentContentTitle(player: Player?) =
     nowPlaying?.title


### PR DESCRIPTION
Intent is now re-set in onCreate to prevent replaying an intent with extras
MediaService now uses the default intent factory method

Solves #20 